### PR TITLE
Implement per-player blackjack shoes and update count command

### DIFF
--- a/changes-today.md
+++ b/changes-today.md
@@ -1,0 +1,10 @@
+# Changes - Latest Blackjack Shoe Updates
+
+## Summary
+- Introduced individualized two-deck blackjack shoes that persist per player, resetting after natural shuffles or one-hour expirations.
+- Updated gameplay commands to draw from each player's personal shoe, surfacing notifications whenever a fresh shoe spins up mid-hand or between rounds.
+- Adjusted the `!count` command and help copy to describe the personal shoe mechanic while still charging 10% of the active bet for access to running/true counts.
+
+## Notes
+- Dealer draws now consume cards from the invoking player's shoe to keep the count accurate for that specific table.
+- Shoe reset alerts appear during `!blackjack`, `!hit`, `!stand`, and `!count` to remove ambiguity about when the count has been cleared.


### PR DESCRIPTION
## Summary
- create per-player two-deck blackjack shoes that persist across hands, refreshing on natural shuffles or hourly expiration
- update blackjack gameplay, including `!hit`, `!stand`, and `!count`, to draw from the caller's shoe and announce resets when they happen
- document today's adjustments in a new `changes-today.md` summary file

## Testing
- node --check bot.js

------
https://chatgpt.com/codex/tasks/task_e_68cafd7ca284832684f969fc9c9c63e1